### PR TITLE
Fix #2690 - Show location encoding error with latin-1 when changing r…

### DIFF
--- a/gui/slick/js/browser.js
+++ b/gui/slick/js/browser.js
@@ -78,7 +78,7 @@
         // make a fileBrowserDialog object if one doesn't exist already
         if (!fileBrowserDialog) {
             // set up the jquery dialog
-            fileBrowserDialog = $('<div class="fileBrowserDialog" style="display:hidden"></div>').appendTo('body').dialog({
+            fileBrowserDialog = $('<div class="fileBrowserDialog" style="display:none"></div>').appendTo('body').dialog({
                 dialogClass: 'browserDialog',
                 title:       options.title,
                 position:    { my: 'center top', at: 'center top+60', of: window },
@@ -99,7 +99,7 @@
             'class': 'btn',
             click: function () {
                 // store the browsed path to the associated text field
-                callback(currentBrowserPath, options);
+                callback($('.fileBrowserField').val(), options);
                 $(this).dialog('close');
             }
         }, {
@@ -171,11 +171,13 @@
         if (ls && options.key) {
             path = localStorage['fileBrowser-' + options.key];
         }
-        if (options.key && options.field.val().length === 0 && (path)) {
+        if (options.key && options.field.val().length === 0 && path) {
             options.field.val(path);
         }
 
         callback = function (path, options) {
+
+            path = $('.fileBrowserField').val();
             // store the browsed path to the associated text field
             options.field.val(path);
 

--- a/gui/slick/views/editShow.mako
+++ b/gui/slick/views/editShow.mako
@@ -31,7 +31,7 @@
         </div>
         <div class="row">
             <div class="col-md-12">
-                <form action="editShow" method="post">
+                <form action="editShow" method="post" accept-charset="utf-8">
 
                     <div id="config-components">
                         <!-- Tabs -->

--- a/gui/slick/views/layouts/main.mako
+++ b/gui/slick/views/layouts/main.mako
@@ -20,6 +20,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="robots" content="noindex, nofollow">
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
@@ -334,7 +335,7 @@
                     <script type="text/javascript" src="${srRoot}/js/core.min.js?${sbPID}"></script>
                 % endif
                 <script type="text/javascript" src="${srRoot}/js/lib/jquery.scrolltopcontrol-1.1.js?${sbPID}"></script>
-                <script type="text/javascript" src="${srRoot}/js/browser.js?${sbPID}"></script>
+                <script type="text/javascript" src="${srRoot}/js/browser.js?${sbPID}" charset="utf-8"></script>
                 <script type="text/javascript" src="${srRoot}/js/ajaxNotifications.js?${sbPID}"></script>
             % endif
             <%block name="scripts" />

--- a/gui/slick/views/manage_massEdit.mako
+++ b/gui/slick/views/manage_massEdit.mako
@@ -13,8 +13,8 @@
 
         anyQualities, bestQualities = common.Quality.splitQuality(initial_quality)
     %>
-    <script type="text/javascript" src="${srRoot}/js/qualityChooser.js?${sbPID}"></script>
-    <script type="text/javascript" src="${srRoot}/js/massEdit.js?${sbPID}"></script>
+    <script type="text/javascript" src="${srRoot}/js/qualityChooser.js?${sbPID}" charset="utf-8"></script>
+    <script type="text/javascript" src="${srRoot}/js/massEdit.js?${sbPID}" charset="utf-8"></script>
 </%block>
 
 <%block name="tabs">
@@ -22,7 +22,7 @@
 </%block>
 
 <%block name="pages">
-    <form id="configForm" action="massEditSubmit" method="post">
+    <form id="configForm" action="massEditSubmit" method="post" accept-charset="utf-8">
         <input type="hidden" name="toEdit" value="${showList}" />
 
         <div id="main">

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1578,7 +1578,9 @@ class Home(WebRoot):
                 show_obj.rls_ignore_words = rls_ignore_words.strip()
                 show_obj.rls_require_words = rls_require_words.strip()
 
-            location = location.decode('UTF-8')
+            if not isinstance(location, unicode):
+                location = ek(unicode, location, 'utf-8')
+
             # if we change location clear the db of episodes, change it, write to db, and rescan
             if ek(os.path.normpath, show_obj._location) != ek(os.path.normpath, location):  # pylint: disable=protected-access
                 logger.log(ek(os.path.normpath, show_obj._location) + " != " + ek(os.path.normpath, location), logger.DEBUG)  # pylint: disable=protected-access
@@ -3398,12 +3400,8 @@ class Manage(Home, WebRoot):
                        subtitles=None, air_by_date=None, anyQualities=None, bestQualities=None, toEdit=None, *args_,
                        **kwargs):
         dir_map = {}
-        for cur_arg in kwargs:
-            if not cur_arg.startswith('orig_root_dir_'):
-                continue
-            which_index = cur_arg.replace('orig_root_dir_', '')
-            end_dir = kwargs['new_root_dir_' + which_index]
-            dir_map[kwargs[cur_arg]] = end_dir
+        for cur_arg in filter(lambda x: x.startswith('orig_root_dir_'), kwargs):
+            dir_map[kwargs[cur_arg]] = ek(unicode, kwargs[cur_arg.replace('orig_root_dir_', 'new_root_dir_')], 'utf-8')
 
         showIDs = toEdit.split("|")
         errors = []

--- a/sickrage/helper/encoding.py
+++ b/sickrage/helper/encoding.py
@@ -50,7 +50,7 @@ def ek(function, *args, **kwargs):
 
 def ss(var):
     """
-    Converts string to Unicode, fallback encoding is forced UTF-8
+    Converts basestring to SYS_ENCODING, fallback encoding is forced UTF-8
 
     :param var: String to convert
     :return: Converted string


### PR DESCRIPTION
…oot dir in mass edit or location in editShow

Set utf-8 for accept-encoding and encoding of some js files
Fix problem where users got confused that the filebrowser didnt keep the location they typed in the location filebrowser but didnt hit enter, now it uses the location in the text box always, which is also updated when you click dirs

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
